### PR TITLE
Potential fix for code scanning alert no. 1: Full server-side request forgery

### DIFF
--- a/api/routers/quick.py
+++ b/api/routers/quick.py
@@ -1,6 +1,9 @@
 """Quick scan endpoints."""
 
+import ipaddress
+import socket
 from datetime import UTC
+from urllib.parse import urlparse
 
 import httpx
 from fastapi import APIRouter, HTTPException, Query
@@ -8,10 +11,6 @@ from fastapi import APIRouter, HTTPException, Query
 from api.models import CheckResult
 from api.services.nikto import run_nikto_scan
 from api.services.nuclei import run_nuclei_scan
-
-import ipaddress
-import socket
-from urllib.parse import urlparse
 
 router = APIRouter()
 
@@ -76,11 +75,7 @@ async def quick_dns_check(
     def _is_public_ip_address(ip_str: str) -> bool:
         ip = ipaddress.ip_address(ip_str)
         return not (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_multicast
-            or ip.is_reserved
+            ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_multicast or ip.is_reserved
         )
 
     def _validate_public_hostname(hostname: str) -> None:
@@ -132,10 +127,11 @@ async def quick_dns_check(
             },
             findings=[],
             error=None,
+        )
+
     except HTTPException:
         # Re-raise HTTP errors (validation failures) directly
         raise
-        )
 
     except Exception as e:
         return CheckResult(

--- a/uv.lock
+++ b/uv.lock
@@ -1144,7 +1144,7 @@ wheels = [
 
 [[package]]
 name = "web-check"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Potential fix for [https://github.com/KevinDeBenedetti/web-check/security/code-scanning/1](https://github.com/KevinDeBenedetti/web-check/security/code-scanning/1)

In general, to fix full SSRF you must not pass arbitrary user-controlled hostnames/URLs directly to HTTP clients. Either (a) select from a server-controlled allowlist of targets, or (b) validate and resolve the user-provided host, ensure it does not resolve to private/loopback/link-local/etc. IP ranges, and then perform the request using that verified IP (and a custom transport if needed to pin the IP).

For this endpoint, the best fix that preserves functionality is to validate the extracted `domain` as a hostname and block domains that resolve to private or otherwise unsafe IP ranges. Concretely in `api/routers/quick.py` within `quick_dns_check`:

- Parse the user input to extract a hostname in a more robust way.
- Use `socket.getaddrinfo` to resolve the hostname and obtain IP addresses.
- For each resolved IP, use the standard library `ipaddress` module to check it is not in private, loopback, link-local, multicast, or reserved ranges. If any resolved IP is unsafe, return an HTTP 400 error instead of making the `httpx` request.
- Only after successful validation, perform the `httpx.AsyncClient().get(...)` to `https://{domain}`.

This requires adding imports for `ipaddress`, `socket`, and `urllib.parse.urlparse` (we can add them near the top of `api/routers/quick.py` alongside existing imports) and adding a small helper function (within the shown file) to validate the domain/IP. All changes will be confined to `api/routers/quick.py` and will not alter the external API surface beyond rejecting unsafe domains.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
