### PR TITLE
fix: release please and security

### DIFF
--- a/.github/release/release-please-config.json
+++ b/.github/release/release-please-config.json
@@ -48,14 +48,7 @@
   "packages": {
     ".": {
       "package-name": "web-check",
-      "changelog-path": "CHANGELOG.md",
-      "extra-files": [
-        {
-          "type": "toml",
-          "path": "pyproject.toml",
-          "jsonpath": "$.project.version"
-        }
-      ]
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "pull-request-title-pattern": "chore(release): release ${version}",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 
 name: CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types:

--- a/Makefile
+++ b/Makefile
@@ -105,20 +105,20 @@ run: ## Run API locally (outside Docker)
 
 test: ## Run tests
 	@echo "$(GREEN)🧪 Running tests...$(NC)"
-	@uv run pytest tests/ -v
+	@uv run pytest api/tests/ -v
 
 lint: ## Lint code
 	@echo "$(GREEN)🔍 Linting...$(NC)"
-	@uv run ruff check api/ tests/
+	@uv run ruff check api/
 
 format: ## Format code
 	@echo "$(GREEN)✨ Formatting code...$(NC)"
-	@uv run ruff format api/ tests/
+	@uv run ruff format api/
 
 check: ## Run all code quality checks
 	@echo "$(GREEN)✅ Running all checks...$(NC)"
-	@uv run ruff format --check api/ tests/
-	@uv run ruff check api/ tests/
+	@uv run ruff format --check api/
+	@uv run ruff check api/
 	@uv run ty check api/
 	@echo "$(GREEN)✅ All checks passed!$(NC)"
 

--- a/api/routers/quick.py
+++ b/api/routers/quick.py
@@ -74,9 +74,7 @@ async def quick_dns_check(
 
     # Domains that this endpoint is allowed to contact.
     # Replace or extend this tuple with the domains that are acceptable in your deployment.
-    ALLOWED_DOMAINS = (
-        "example.com",
-    )
+    ALLOWED_DOMAINS = ("example.com",)
 
     def _is_public_ip_address(ip_str: str) -> bool:
         ip = ipaddress.ip_address(ip_str)
@@ -100,10 +98,7 @@ async def quick_dns_check(
         hostname_lower = hostname.lower().rstrip(".")
         for allowed in ALLOWED_DOMAINS:
             allowed_lower = allowed.lower().rstrip(".")
-            if (
-                hostname_lower == allowed_lower
-                or hostname_lower.endswith("." + allowed_lower)
-            ):
+            if hostname_lower == allowed_lower or hostname_lower.endswith("." + allowed_lower):
                 return True
         return False
 
@@ -117,7 +112,7 @@ async def quick_dns_check(
         # Ensure all resolved addresses are public
         for family, _, _, _, sockaddr in addrinfo:
             if family in (socket.AF_INET, socket.AF_INET6):
-                ip_str = sockaddr[0]
+                ip_str = str(sockaddr[0])
                 if not _is_public_ip_address(ip_str):
                     raise HTTPException(
                         status_code=400,


### PR DESCRIPTION
Potential fix for [https://github.com/KevinDeBenedetti/web-check/security/code-scanning/1](https://github.com/KevinDeBenedetti/web-check/security/code-scanning/1)

In general, to fix full SSRF you should avoid requesting arbitrary attacker-specified hosts. Instead, map user input to a safe, server-controlled set of targets (allow-list), or perform strict validation on the hostname so that only domains you explicitly trust can be reached.

In this case, the minimal fix without changing apparent functionality too much is to add hostname validation that only allows domains within an explicit set of allowed suffixes (for example, your own domains), and to reject any other hostnames, including raw IP addresses. We can implement a helper `_is_allowed_domain` that enforces: (1) hostname is not an IP address, and (2) hostname is either exactly an allowed domain or a subdomain of it. We then call this helper after `_extract_hostname` and before `_validate_public_hostname`. If the hostname is not allowed, we raise `HTTPException(400, ...)`. This keeps the structure of the endpoint intact but ensures the `client.get(f"https://{domain}")` will only ever be made to allowed domains and not arbitrary external hosts.

Concretely:
- In `quick_dns_check`, define a small allow-list such as `ALLOWED_DOMAINS = ("example.com",)` (replace with your real domains).
- Add a helper `_is_allowed_domain(hostname: str) -> bool` and use `ipaddress.ip_address` to reject raw IP addresses.
- After computing `domain = _extract_hostname(url)` and checking it is non-empty, call `_is_allowed_domain(domain)` and raise `HTTPException` if it returns `False`.
- Leave the rest of the logic unchanged, including the existing public-IP checks and the `httpx` request.

All changes are confined to `api/routers/quick.py` inside the shown `quick_dns_check` function.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
