### PR TITLE
ci: use GitHub App token for release-please

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,7 +74,10 @@ jobs:
     name: Release
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: KevinDeBenedetti/github-workflows/.github/workflows/release.yml@main
-    secrets: inherit
+    with:
+      app-client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+    secrets:
+      APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
   # ── CD — Build & push API Docker image (on release) ───────────────────────
   deploy-api:


### PR DESCRIPTION
Switch release-please to a GitHub App token instead of the default `GITHUB_TOKEN`.

- Pass `app-client-id` (from `vars.RELEASE_APP_CLIENT_ID`) and `APP_PRIVATE_KEY`
  (from `secrets.RELEASE_APP_PRIVATE_KEY`) to the reusable `release.yml`.
- The release PR is now opened by the App instead of `github-actions[bot]`,
  which removes the manual "approve workflow" gate and lets CI run on the
  release PR.

Requires the GitHub App installed on this repo with contents / pull-requests /
issues: write, plus the `RELEASE_APP_CLIENT_ID` variable and
`RELEASE_APP_PRIVATE_KEY` secret (already set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
